### PR TITLE
Convert Twig functions to methods on the Twig extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
 	"require" : {
 		"php" : ">=5.4.0",
 		"mouf/html.htmlelement" : "~2.0",
-		"twig/twig" : "1.*@stable",
+		"twig/twig" : "~1.19",
 		"mouf/utils.cache.cache-interface" : "~2.0",
 	    "container-interop/container-interop" : "~1.0"
 	},


### PR DESCRIPTION
This allows twig to compile the calls to faster code, as it does not need to load functions from all extensions to access the callable.
The implementation of the t() function has also been changed to collect parameters at compile-time instead of using func_get_args in the function (which does not always work because Twig validates the number of arguments passed to the function when using named arguments). this bumped the requirement to Twig 1.19+, but it should not be an issue: there is no reason to stay on older Twig versions as it is fully BC (and older versions have bugs).

Another nice side effect of this change is that it will make blackfire profiling much more readable, by knowing which function takes time. 58% of the Packanalyst time is currently spent in `\Mouf\Html\Renderer\Twig\MoufTwigExtension::{closure}` in the profile I ran, but this does not allow knowing which function it is.
