### PR TITLE
remove t() extension as it if now handled by Fine itself

### DIFF
--- a/src/Mouf/Html/Renderer/Twig/MoufTwigExtension.php
+++ b/src/Mouf/Html/Renderer/Twig/MoufTwigExtension.php
@@ -56,11 +56,6 @@ class MoufTwigExtension extends Twig_Extension
                 new \Twig_SimpleFunction('val', [$this, 'getValue']),
 
                 /**
-                 * The t function will call the iMsgNoEdit() method of the string passed in parameter
-                 */
-                new \Twig_SimpleFunction('t', [$this, 'translate'], array('is_variadic' => true, 'deprecated' => true, 'alternative' => '"t" filter')),
-
-                /**
                  * The l function will create a relative URL : in fact, it simply preprends the ROOT_URL
                  */
                 new \Twig_SimpleFunction('l', [$this, 'createRelativeLink'], array('deprecated' => true)),

--- a/src/Mouf/Html/Renderer/Twig/MoufTwigExtension.php
+++ b/src/Mouf/Html/Renderer/Twig/MoufTwigExtension.php
@@ -72,18 +72,6 @@ class MoufTwigExtension extends Twig_Extension
         );
     }
 
-    /**
-     * Returns a list of filters to add to the existing list.
-     *
-     * @return array An array of filters
-     */
-    public function getFilters()
-    {
-        return array(
-            new \Twig_SimpleFilter('t', [$this, 'translate'], array('is_variadic' => true)),
-        );
-    }
-
     public function toHtml($param)
     {
         if ($param == null) {


### PR DESCRIPTION
`t()` extention used for translating texts using Fine has now moved directly to the [Fine package](https://github.com/thecodingmachine/utils.i18n.fine.common/blob/4.0/src/FineTwigExtension.php).

It must be therefore removed from this package as it will override the FineExtension, and won't work with Fine version > 3.

Breaking change branch to 2.0 because previous verisions will fail without the "embeded" extension.
